### PR TITLE
SuperLinter & deal with Files being created as root

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,55 @@
+---
+###########################
+###########################
+## Linter GitHub Actions ##
+###########################
+###########################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    branches-ignore: [master]
+    # Remove the line above to run when pushing to master
+  pull_request:
+    branches: [master]
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter@v3
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,10 +16,10 @@ name: Lint Code Base
 #############################
 on:
   push:
-    branches-ignore: [master]
-    # Remove the line above to run when pushing to master
+    branches-ignore: [main]
+    # Remove the line above to run when pushing to main
   pull_request:
-    branches: [master]
+    branches: [main]
 
 ###############
 # Set the Job #
@@ -51,5 +51,5 @@ jobs:
         uses: github/super-linter@v3
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,9 +15,6 @@ name: Lint Code Base
 # Start the job on all push #
 #############################
 on:
-  push:
-    branches-ignore: [main]
-    # Remove the line above to run when pushing to main
   pull_request:
     branches: [main]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # terraform-localstack-docker-cli
 
+[![GitHub Super-Linter](https://github.com/datfinesoul/terraform-localstack-docker-cli/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
+
 Examples of:
 - Running Terraform CLI from within a docker container on the Host
 - Running Terraform scripts against localstack
@@ -43,6 +45,7 @@ function tf () {
     --tty \
     --network host \
     --volume "$(pwd):/tf:rw" \
+    --user "$(id -u):$(id -g)" \
     --workdir '/tf' \
     hashicorp/terraform:light \
     "$@"

--- a/docker-compose.terraform.yml
+++ b/docker-compose.terraform.yml
@@ -9,3 +9,4 @@ services:
         source: "${PWD}"
         target: /tf
     working_dir: /tf
+    user: "${TF_UID}:${TF_GID}"

--- a/docker-compose.terraform.yml
+++ b/docker-compose.terraform.yml
@@ -5,5 +5,7 @@ services:
     image: hashicorp/terraform:0.13.4
     network_mode: host
     volumes:
-      - "${PWD}:/tf"
+      - type: bind
+        source: "${PWD}"
+        target: /tf
     working_dir: /tf

--- a/tf
+++ b/tf
@@ -1,2 +1,8 @@
 #!/usr/bin/env bash
-docker-compose -f docker-compose.terraform.yml -p terraform run terraform "$@"
+export TF_UID="$(id -u)"
+export TF_GID="$(id -u)"
+docker-compose \
+  -f docker-compose.terraform.yml \
+  -p terraform \
+  run \
+  terraform "$@"

--- a/tf
+++ b/tf
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-export TF_UID="$(id -u)"
-export TF_GID="$(id -u)"
+TF_UID="$(id -u)"
+TF_GID="$(id -u)"
+export TF_UID TF_GID
 docker-compose \
   -f docker-compose.terraform.yml \
   -p terraform \

--- a/tf
+++ b/tf
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 TF_UID="$(id -u)"
-TF_GID="$(id -u)"
+TF_GID="$(id -g)"
 export TF_UID TF_GID
 docker-compose \
   -f docker-compose.terraform.yml \


### PR DESCRIPTION
- Adding SuperLinter
- When running `./tf`, the `./.terraform` directory and `./terraform.tfstate` files would be created as the root user due to how Docker works under the hood by default.  This PR addresses this, but making the user that executes the docker container's TF CLI, the current user.